### PR TITLE
Atualizar README para kolourpaint e simplificar AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,177 +1,31 @@
 # Instruções Gerais
 
 * O usuário irá fornecer uma tarefa.
-* A tarefa envolve trabalhar com repositórios Git no seu diretório de trabalho atual.
-* Aguarde até que todos os comandos de terminal sejam concluídos (ou cancelados) antes de finalizar.
+* A tarefa envolve trabalhar com repositórios Git no diretório atual.
+* Aguarde a conclusão dos comandos de terminal antes de finalizar.
 
 ## Git
 
-Se para executar a tarefa for necessário criar ou modificar arquivos:
-
-* **Não** crie novos `branches` e, se for preciso criar, comece o nome da branch com `codex` e não utilize caracteres especiais no nome da branch.
-* Use o Git para **commitar** suas alterações.
+* Não crie novos branches.
+* Use o Git para commitar suas alterações.
 * Se o *pre-commit* falhar, corrija os problemas e tente novamente.
-* Verifique `git status` para confirmar que sua *worktree* está limpa.
-* Apenas o código **committed** será avaliado.
-* **Não** modifique ou altere *commits* existentes.
-* Sempre faça as alterações baseadas no último `commit` da branch `main`.
+* Verifique `git status` para confirmar que a *worktree* está limpa.
+* Não modifique *commits* existentes.
 
 ## Especificação de `AGENTS.md`
 
-* Repositórios podem conter arquivos `AGENTS.md` em `/`, `~` ou pastas internas.
-* Eles orientam humanos sobre convenções de código, organização e execução do projeto.
-* Se contiverem instruções sobre mensagens de Pull Request, **respeite-as**.
-* O escopo é a árvore de diretórios a partir de onde estão.
-* `AGENTS.md` aninhados têm precedência sobre os mais gerais.
-* Instruções de sistema/desenvolvedor/usuário na conversa têm precedência sobre o `AGENTS.md`.
-* Se o `AGENTS.md` define checagens programáticas, **execute-as** e certifique-se de que passam.
+* Repositórios podem conter arquivos `AGENTS.md`.
+* As instruções valem para todo o diretório abaixo do arquivo.
+* Arquivos `AGENTS.md` mais profundos têm precedência.
+* Instruções de sistema, desenvolvedor e usuário prevalecem sobre este arquivo.
+* Execute as verificações programáticas indicadas.
 
 ## Instruções de Citação
 
-* Se navegar em arquivos ou usar comandos de terminal, **cite** no texto final:
+* Cite trechos de arquivos usando `【F:<caminho>†L<linha_inicial>(-L<linha_final>)?】`.
+* Cite saídas de terminal usando `【<chunk_id>†L<linha_inicial>(-L<linha_final>)?】`.
+* Prefira citações de arquivos.
 
-  * **Arquivo**: `【F:<caminho_do_arquivo>†L<linha_inicial>(-L<linha_final>)?】`
-  * **Terminal**: `【<chunk_id>†L<linha_inicial>(-L<linha_final>)?】`
-* Prefira citações de **arquivo**.
-* Não cite commits nem URLs diretas.
+## Estilo e Idioma
 
-## Convenções de Código e Documentação
-
-### Python
-
-1. **Cabeçalho**:
-
-```python
-# -*- coding: utf-8 -*-
-```
-
-2. **Linguagem**:
-
-* Texto da resposta: **português brasileiro**.
-* Comentários: **português brasileiro**.
-* Identificadores: **inglês (EUA)**.
-* Saídas (`print`, `input`): **inglês (EUA)**.
-
-3. **Estilo PEP8 / PEP257**:
-
-* Sem espaços em branco no final.
-* 100 colunas por linha.
-
-4. **Docstrings & Sphinx**:
-
-```python
-r"""
-Docstring em pt-BR com bloco Sphinx:
-
-.. math:: \dfrac{u}{v}
-"""
-```
-
-5. **Gráficos em preto e branco**:
-
-* Use marcadores distintos para impressão sem cores.
-* Posicione a legenda à direita do gráfico com `bbox_to_anchor=(1.02, 0.5)`
-  para evitar sobreposição.
-
-### LaTeX
-
-1. **Cabeçalho**:
-
-```latex
-\documentclass[12pt, a4paper]{article}
-\input{preamble.tex}
-\begin{document}
-```
-
-Finalize com:
-
-```latex
-\end{document}
-```
-
-2. **Linguagem**:
-
-* Comentários: **português brasileiro**.
-* Variáveis: **inglês (EUA)**.
-* Traduzir automaticamente `Figure`, `Table`, etc.
-
-3. **Formatação**:
-
-* Sempre usar `\dfrac` no lugar de `\frac` ou `/`.
-* Unidades devem estar em `\mathrm{}`.
-* Use `\autoref` em vez de `\ref` ou `\eqref`.
-* Equações em sistema devem alinhar o `=` com `&` em ambientes `aligned` ou `cases`.
-* Separador decimal é `,`.
-* Figuras devem estar em `\fbox`, exceto capas e diagramas.
-* Tabelas em `tables/` com `\input`.
-* Variáveis devem ser descritas com `\begin{itemize}`.
-
-4. **Nomenclaturas**:
-
-* Ordenar em ordem alfabética.
-* Remover unidades.
-* Pode agrupar por categoria: cinemáticas, térmicas etc.
-* Variáveis de **figuras e diagramas** também devem ser incluídas.
-* Adicionar:
-
-```latex
-\addcontentsline{toc}{section}{Lista de Nomenclaturas}
-\printnomenclature
-```
-
-5. **Padronização**:
-
-* Verificar se todas variáveis seguem mesmo padrão.
-* Corrigir palavras separadas erroneamente (ex: `temper-atura`).
-* Corrigir ortografia.
-* Todas as listagens de código devem ser centralizadas em `appendix.tex`.
-  Os arquivos `main*.tex` precisam incluir esse apêndice com `\input{appendix.tex}`.
-
-6. **Referências ABNT**:
-
-* Autores em CAIXA ALTA.
-* Títulos com apenas a primeira letra maiúscula.
-* Ano ao final.
-* Exemplo:
-
-```latex
-\bibitem{fox2010}
-FOX, R. W.; McDONALD, A. T.; PRITCHARD, P. J.. \textbf{\textit{Introdu\c{c}\~ao \`a mec\^anica dos fluidos}}. 8. ed. Rio de Janeiro: LTC. p. 426--430, 2010.
-```
-
-* Ordenar as referências pela aparição.
-* Trocar citações `AUTOR ANO` por `Autor (ANO)`.
-
-7. **Validações**:
-
-* Verificar se seções têm citações.
-* Verificar se todas referências listadas são citadas.
-* Atualizar acrônimos, definições e nomenclaturas com ordem alfabética e remoção de não usados.
-* Manter identação correta.
-* Explicar gráficos inseridos.
-
-## Organização dos trechos LaTeX
-
-O documento principal deve incluir `preamble.tex` para a configuração de pacotes e comandos gerais e `variable_oficial_names.tex` para as macros institucionais.
-
-### Exemplos para `preamble.tex`
-* Ajustes de hifenização.
-* Todas as chamadas `\usepackage{...}`.
-* Ambientes e comandos como `\newtheorem` e `\DeclarePairedDelimiter`.
-* Configurações do `hyperref` (`\hypersetup{...}`).
-* Definições de espaçamento (`\onehalfspacing`, `\doublespacing` etc.).
-* Criação da lista de nomenclaturas conforme as instruções deste arquivo.
-
-### Exemplos para `variable_oficial_names.tex`
-* `\course{...}`, `\area{...}`.
-* `\author{...}{...}`, `\itaauthoraddress{...}{...}{...}`.
-* `\title{...}`.
-* `\advisor{...}{...}{...}`, `\coadvisor{...}{...}{...}`.
-* `\boss{...}{...}`, `\bosscourse{...}{...}`.
-* Palavras‑chave (`\kwcip{...}`).
-* `\examiner{...}{...}{...}{...}`.
-* `\date{...}{...}{...}`.
-* `\cdu{...}`.
-
-### Seções
-* Iniciar cada capítulo com `\chapter{...}` antes de qualquer `\section`, exceto capa, folha de rosto, dedicatória, agradecimentos, epígrafo, resumo, apêndice ou anexo.
+* Utilize português brasileiro em textos e comentários.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,3 +12,6 @@ facilitar quando incluir uma nova revisão/versão.
 
 **Revisão 1** - 31/07/2025
 - Atualização do README para instalação e uso do `catfish`.
+
+**Revisão 2** - 07/08/2025
+- Atualização do README para instalação e uso do `kolourpaint`.

--- a/README.ipynb
+++ b/README.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Como instalar o `catfish` no `Linux Ubuntu`"
+    "# Como instalar o `kolourpaint` no `Linux Ubuntu`"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "source": [
     "## Resumo\n",
     "\n",
-    "Este documento apresenta os passos necessários para instalar o utilitário `catfish` no `Linux Ubuntu`."
+    "Este documento apresenta os passos necessários para instalar o utilitário `kolourpaint` no `Linux Ubuntu`."
    ]
   },
   {
@@ -22,7 +22,7 @@
    "source": [
     "## _Abstract_\n",
     "\n",
-    "_This document shows the steps required to install the `catfish` utility on `Linux Ubuntu`._"
+    "_This document shows the steps required to install the `kolourpaint` utility on `Linux Ubuntu`._"
    ]
   },
   {
@@ -33,20 +33,20 @@
     }
    },
    "source": [
-    "## Descrição [2]\n",
+    "## Descrição\n",
     "\n",
-    "### `catfish`\n",
+    "### `kolourpaint`\n",
     "\n",
-    "O `catfish` é uma ferramenta de busca para ambientes `Linux`. Ela combina utilitários como `locate` e `find` para localizar arquivos e pastas rapidamente por meio de uma interface simples."
+    "O `kolourpaint` é um editor de imagens simples para ambientes `Linux`. Ele oferece ferramentas básicas de desenho, como linhas, formas e preenchimentos, sendo uma alternativa leve ao `Microsoft Paint`.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. Instalar o `catfish` no `Linux Ubuntu`\n",
+    "## 1. Instalar o `kolourpaint` no `Linux Ubuntu`\n",
     "\n",
-    "Para instalar o `catfish`, siga os passos abaixo:\n",
+    "Para instalar o `kolourpaint`, siga os passos abaixo:\n",
     "\n",
     "1. Abra o `Terminal Emulator`. Você pode fazer isso pressionando: `Ctrl + Alt + T`\n",
     "\n",
@@ -92,11 +92,11 @@
     "    sudo apt full-upgrade -y\n",
     "    ```\n",
     "\n",
-    "3. Instale o `catfish` (pacote `poppler-utils`) e verifique a instalação:\n",
+    "3. Instale o `kolourpaint` e verifique a instalação:\n",
     "    ```bash\n",
     "    sudo apt update\n",
-    "    sudo apt install poppler-utils\n",
-    "    catfish -v\n",
+    "    sudo apt install kolourpaint\n",
+    "    kolourpaint --version\n",
     "    ```\n"
    ]
   },
@@ -104,26 +104,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Realizar uma busca simples\n",
+    "## 2. Abrir uma imagem existente\n",
     "\n",
-    "Você pode executar o `catfish` informando um diretório para a pesquisa:\n",
+    "Você pode abrir o `kolourpaint` informando um arquivo de imagem:\n",
     "```bash\n",
-    "catfish ~/Documentos\n",
+    "kolourpaint ~/Imagens/exemplo.png\n",
     "```\n",
-    "Esse comando abre a interface do programa iniciando a busca na pasta `Documentos`."
+    "Esse comando abre a interface do programa carregando a imagem `exemplo.png`.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Usar uma variável de terminal para definir o caminho de busca\n",
+    "## 3. Usar uma variável de terminal para definir a imagem\n",
     "\n",
-    "Também é possível definir o diretório em uma variável antes de chamar o `catfish`:\n",
+    "Também é possível definir o caminho em uma variável antes de chamar o `kolourpaint`:\n",
     "```bash\n",
-    "search_dir=\"~/Documentos\"\n",
-    "catfish \"$search_dir\"\n",
-    "```"
+    "img_path=\"~/Imagens/exemplo.png\"\n",
+    "kolourpaint \"$img_path\"\n",
+    "```\n"
    ]
   },
   {
@@ -132,7 +132,7 @@
    "source": [
     "## Referências\n",
     "\n",
-    "[1] OPENAI. ***Instalar catfish no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/6862cf14-11c8-8002-8a1d-96488e72f5cf>. ChatGPT. Acessado em: 11/03/2025 14:23."
+    "[1] OPENAI. ***Instalar kolourpaint no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/68942e26-b7a0-832f-9c96-7c57044cb43a>. ChatGPT. Acessado em: 07/08/2025 05:21.\n"
    ]
   }
  ],

--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
-# Como instalar o `catfish` no `Linux Ubuntu`
+# Como instalar o `kolourpaint` no `Linux Ubuntu`
 
 ## Resumo
 
-Este documento apresenta os passos necessários para instalar o utilitário `catfish` no `Linux Ubuntu`.
+Este documento apresenta os passos necessários para instalar o utilitário `kolourpaint` no `Linux Ubuntu`.
 
 ## _Abstract_
 
-_This document shows the steps required to install the `catfish` utility on `Linux Ubuntu`._
+_This document shows the steps required to install the `kolourpaint` utility on `Linux Ubuntu`._
 
-## Descrição [2]
+## Descrição
 
-### `catfish`
+### `kolourpaint`
 
-O `catfish` é uma ferramenta de busca para ambientes `Linux`. Ela combina utilitários como `locate` e `find` para localizar arquivos e pastas rapidamente por meio de uma interface simples.
+O `kolourpaint` é um editor de imagens simples para ambientes `Linux`. Ele oferece ferramentas básicas de desenho, como linhas, formas e preenchimentos, sendo uma alternativa leve ao `Microsoft Paint`.
 
+## 1. Instalar o `kolourpaint` no `Linux Ubuntu`
 
-
-## 1. Instalar o `catfish` no `Linux Ubuntu`
-
-Para instalar o `catfish`, siga os passos abaixo:
+Para instalar o `kolourpaint`, siga os passos abaixo:
 
 1. Abra o `Terminal Emulator`. Você pode fazer isso pressionando: `Ctrl + Alt + T`
 
@@ -64,30 +62,30 @@ Para instalar o `catfish`, siga os passos abaixo:
     sudo apt full-upgrade -y
     ```
 
-3. Instale o `catfish` (pacote `poppler-utils`) e verifique a instalação:
+3. Instale o `kolourpaint` e verifique a instalação:
     ```bash
     sudo apt update
-    sudo apt install poppler-utils
-    catfish -v
+    sudo apt install kolourpaint
+    kolourpaint --version
     ```
 
+## 2. Abrir uma imagem existente
 
-## 2. Realizar uma busca simples
-
-Você pode executar o `catfish` informando um diretório para a pesquisa:
+Você pode abrir o `kolourpaint` informando um arquivo de imagem:
 ```bash
-catfish ~/Documentos
+kolourpaint ~/Imagens/exemplo.png
 ```
-Esse comando abre a interface do programa iniciando a busca na pasta `Documentos`.
+Esse comando abre a interface do programa carregando a imagem `exemplo.png`.
 
-## 3. Usar uma variável de terminal para definir o caminho de busca
+## 3. Usar uma variável de terminal para definir a imagem
 
-Também é possível definir o diretório em uma variável antes de chamar o `catfish`:
+Também é possível definir o caminho em uma variável antes de chamar o `kolourpaint`:
 ```bash
-search_dir="~/Documentos"
-catfish "$search_dir"
+img_path="~/Imagens/exemplo.png"
+kolourpaint "$img_path"
 ```
 
 ## Referências
 
-[1] OPENAI. ***Instalar catfish no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/6862cf14-11c8-8002-8a1d-96488e72f5cf>. ChatGPT. Acessado em: 11/03/2025 14:23.
+[1] OPENAI. ***Instalar kolourpaint no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/68942e26-b7a0-832f-9c96-7c57044cb43a>. ChatGPT. Acessado em: 07/08/2025 05:21.
+

--- a/README.py
+++ b/README.py
@@ -1,27 +1,22 @@
-#!/usr/bin/env python
-# coding: utf-8
-
-# # Como instalar o `catfish` no `Linux Ubuntu`
-
+# # Como instalar o `kolourpaint` no `Linux Ubuntu`
+#
 # ## Resumo
 # 
-# Este documento apresenta os passos necessários para instalar o utilitário `catfish` no `Linux Ubuntu`.
-
+# Este documento apresenta os passos necessários para instalar o utilitário `kolourpaint` no `Linux Ubuntu`.
+#
 # ## _Abstract_
 # 
-# _This document shows the steps required to install the `catfish` utility on `Linux Ubuntu`._
-
-# ## Descrição [2]
-# 
-# ### `catfish`
+# _This document shows the steps required to install the `kolourpaint` utility on `Linux Ubuntu`._
 #
-# O `catfish` é uma ferramenta de busca para ambientes `Linux`. Ela combina utilitários como `locate` e `find` para localizar arquivos e pastas rapidamente por meio de uma interface simples.
+# ## Descrição
 # 
+# ### `kolourpaint`
 # 
-
-# ## 1. Instalar o `catfish` no `Linux Ubuntu`
+# O `kolourpaint` é um editor de imagens simples para ambientes `Linux`. Ele oferece ferramentas básicas de desenho, como linhas, formas e preenchimentos, sendo uma alternativa leve ao `Microsoft Paint`.
+#
+# ## 1. Instalar o `kolourpaint` no `Linux Ubuntu`
 # 
-# Para instalar o `catfish`, siga os passos abaixo:
+# Para instalar o `kolourpaint`, siga os passos abaixo:
 # 
 # 1. Abra o `Terminal Emulator`. Você pode fazer isso pressionando: `Ctrl + Alt + T`
 # 
@@ -67,31 +62,30 @@
 #     sudo apt full-upgrade -y
 #     ```
 # 
-# 3. Instale o `catfish` (pacote `poppler-utils`) e verifique a instalação:
+# 3. Instale o `kolourpaint` e verifique a instalação:
 #     ```bash
 #     sudo apt update
-#     sudo apt install poppler-utils
-#     catfish -v
-# ```
-
-# ## 2. Realizar uma busca simples
+#     sudo apt install kolourpaint
+#     kolourpaint --version
+#     ```
 #
-# Você pode executar o `catfish` informando um diretório para a pesquisa:
-# ```bash
-# catfish ~/Documentos
-# ```
-# Esse comando abre a interface do programa iniciando a busca na pasta `Documentos`.
-#
-# ## 3. Usar uma variável de terminal para definir o caminho de busca
-#
-# Também é possível definir o diretório em uma variável antes de chamar o `catfish`:
-# ```bash
-# search_dir="~/Documentos"
-# catfish "$search_dir"
-# ```
+# ## 2. Abrir uma imagem existente
 # 
-
-
+# Você pode abrir o `kolourpaint` informando um arquivo de imagem:
+# ```bash
+# kolourpaint ~/Imagens/exemplo.png
+# ```
+# Esse comando abre a interface do programa carregando a imagem `exemplo.png`.
+#
+# ## 3. Usar uma variável de terminal para definir a imagem
+# 
+# Também é possível definir o caminho em uma variável antes de chamar o `kolourpaint`:
+# ```bash
+# img_path="~/Imagens/exemplo.png"
+# kolourpaint "$img_path"
+# ```
+#
 # ## Referências
 # 
-# [1] OPENAI. ***Instalar catfish no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/6862cf14-11c8-8002-8a1d-96488e72f5cf>. ChatGPT. Acessado em: 11/03/2025 14:23.
+# [1] OPENAI. ***Instalar kolourpaint no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/68942e26-b7a0-832f-9c96-7c57044cb43a>. ChatGPT. Acessado em: 07/08/2025 05:21.
+#


### PR DESCRIPTION
## Resumo
- adaptar documentação para instalação e uso do kolourpaint
- simplificar AGENTS.md para instruções essenciais

## Testes
- `python convert_ipynb_to_md_and_py.py` *(falhou: No module named 'nbconvert')*
- `pip install nbconvert` *(falhou: Could not find a version that satisfies the requirement nbconvert)*

------
https://chatgpt.com/codex/tasks/task_e_68943783a50c8322b9814ae8ab30e045