### PR TITLE
Resolvido conflito nos arquivos README

### DIFF
--- a/README.ipynb
+++ b/README.ipynb
@@ -2,72 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5b4ae69a",
    "metadata": {},
    "source": [
-<<<<<<< HEAD
-    "# Como instalar o `catfish` no `Linux Ubuntu`\n",
+    "# Como instalar o `kolourpaint` no `Linux Ubuntu`\n",
     "\n",
     "## Resumo\n",
     "\n",
-    "Este documento apresenta os passos necessários para instalar o utilitário `catfish` no `Linux Ubuntu`.\n",
+    "Este documento apresenta os passos necessários para instalar o utilitário `kolourpaint` no `Linux Ubuntu`.\n",
     "\n",
     "## _Abstract_\n",
     "\n",
-    "_This document shows the steps required to install the `catfish` utility on `Linux Ubuntu`._\n",
+    "_This document shows the steps required to install the `kolourpaint` utility on `Linux Ubuntu`._\n",
     "\n",
-    "## Descrição [2]\n",
-=======
-    "# Como instalar o `kolourpaint` no `Linux Ubuntu`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Resumo\n",
-    "\n",
-    "Este documento apresenta os passos necessários para instalar o utilitário `kolourpaint` no `Linux Ubuntu`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## _Abstract_\n",
-    "\n",
-    "_This document shows the steps required to install the `kolourpaint` utility on `Linux Ubuntu`._"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
-   "source": [
     "## Descrição\n",
->>>>>>> codex/revise-project-for-kolourpaint-installation
     "\n",
     "### `kolourpaint`\n",
     "\n",
-<<<<<<< HEAD
-    "O `catfish` é uma ferramenta de busca para ambientes `Linux`. Ela combina utilitários como `locate` e `find` para localizar arquivos e pastas rapidamente por meio de uma interface simples.\n",
+    "O `kolourpaint` é um editor de imagens simples para ambientes `Linux`. Ele oferece ferramentas básicas de desenho, como linhas, formas e preenchimentos, sendo uma alternativa leve ao `Microsoft Paint`.\n",
     "\n",
-    "\n",
-    "\n",
-    "## 1. Instalar o `catfish` no `Linux Ubuntu`\n",
-=======
-    "O `kolourpaint` é um editor de imagens simples para ambientes `Linux`. Ele oferece ferramentas básicas de desenho, como linhas, formas e preenchimentos, sendo uma alternativa leve ao `Microsoft Paint`.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## 1. Instalar o `kolourpaint` no `Linux Ubuntu`\n",
->>>>>>> codex/revise-project-for-kolourpaint-installation
     "\n",
     "Para instalar o `kolourpaint`, siga os passos abaixo:\n",
     "\n",
@@ -118,69 +71,30 @@
     "3. Instale o `kolourpaint` e verifique a instalação:\n",
     "    ```bash\n",
     "    sudo apt update\n",
-<<<<<<< HEAD
-    "    sudo apt install poppler-utils\n",
-    "    catfish -v\n",
-    "    ```\n",
-    "\n",
-    "\n",
-    "## 2. Realizar uma busca simples\n",
-=======
     "    sudo apt install kolourpaint\n",
     "    kolourpaint --version\n",
-    "    ```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "    ```\n",
+    "\n",
     "## 2. Abrir uma imagem existente\n",
->>>>>>> codex/revise-project-for-kolourpaint-installation
     "\n",
     "Você pode abrir o `kolourpaint` informando um arquivo de imagem:\n",
     "```bash\n",
     "kolourpaint ~/Imagens/exemplo.png\n",
     "```\n",
-<<<<<<< HEAD
-    "Esse comando abre a interface do programa iniciando a busca na pasta `Documentos`.\n",
+    "Esse comando abre a interface do programa carregando a imagem `exemplo.png`.\n",
     "\n",
-    "## 3. Usar uma variável de terminal para definir o caminho de busca\n",
-=======
-    "Esse comando abre a interface do programa carregando a imagem `exemplo.png`.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## 3. Usar uma variável de terminal para definir a imagem\n",
->>>>>>> codex/revise-project-for-kolourpaint-installation
     "\n",
     "Também é possível definir o caminho em uma variável antes de chamar o `kolourpaint`:\n",
     "```bash\n",
-<<<<<<< HEAD
-    "search_dir=\"~/Documentos\"\n",
-    "catfish \"$search_dir\"\n",
+    "img_path=\"~/Imagens/exemplo.png\"\n",
+    "kolourpaint \"$img_path\"\n",
     "```\n",
     "\n",
     "## Referências\n",
     "\n",
-    "[1] OPENAI. ***Instalar catfish no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/6862cf14-11c8-8002-8a1d-96488e72f5cf>. ChatGPT. Acessado em: 11/03/2025 14:23.\n"
-=======
-    "img_path=\"~/Imagens/exemplo.png\"\n",
-    "kolourpaint \"$img_path\"\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Referências\n",
-    "\n",
-    "[1] OPENAI. ***Instalar kolourpaint no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/68942e26-b7a0-832f-9c96-7c57044cb43a>. ChatGPT. Acessado em: 07/08/2025 05:21.\n"
->>>>>>> codex/revise-project-for-kolourpaint-installation
+    "[1] OPENAI. ***Instalar kolourpaint no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/68942e26-b7a0-832f-9c96-7c57044cb43a>. ChatGPT. Acessado em: 07/08/2025 05:21.\n",
+    "\n"
    ]
   }
  ],

--- a/README.md
+++ b/README.md
@@ -87,9 +87,5 @@ kolourpaint "$img_path"
 
 ## Referências
 
-<<<<<<< HEAD
-[1] OPENAI. ***Instalar catfish no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/6862cf14-11c8-8002-8a1d-96488e72f5cf>. ChatGPT. Acessado em: 11/03/2025 14:23.
-=======
 [1] OPENAI. ***Instalar kolourpaint no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/68942e26-b7a0-832f-9c96-7c57044cb43a>. ChatGPT. Acessado em: 07/08/2025 05:21.
->>>>>>> codex/revise-project-for-kolourpaint-installation
 

--- a/README.py
+++ b/README.py
@@ -1,46 +1,22 @@
-<<<<<<< HEAD
 #!/usr/bin/env python
 # coding: utf-8
-
-# # Como instalar o `catfish` no `Linux Ubuntu`
-# 
-# ## Resumo
-# 
-# Este documento apresenta os passos necessários para instalar o utilitário `catfish` no `Linux Ubuntu`.
-# 
-# ## _Abstract_
-# 
-# _This document shows the steps required to install the `catfish` utility on `Linux Ubuntu`._
-# 
-# ## Descrição [2]
-# 
-# ### `catfish`
-# 
-# O `catfish` é uma ferramenta de busca para ambientes `Linux`. Ela combina utilitários como `locate` e `find` para localizar arquivos e pastas rapidamente por meio de uma interface simples.
-=======
 # # Como instalar o `kolourpaint` no `Linux Ubuntu`
-#
+# 
 # ## Resumo
 # 
 # Este documento apresenta os passos necessários para instalar o utilitário `kolourpaint` no `Linux Ubuntu`.
-#
+# 
 # ## _Abstract_
 # 
 # _This document shows the steps required to install the `kolourpaint` utility on `Linux Ubuntu`._
-#
+# 
 # ## Descrição
->>>>>>> codex/revise-project-for-kolourpaint-installation
 # 
 # ### `kolourpaint`
 # 
-<<<<<<< HEAD
-# 
-# ## 1. Instalar o `catfish` no `Linux Ubuntu`
-=======
 # O `kolourpaint` é um editor de imagens simples para ambientes `Linux`. Ele oferece ferramentas básicas de desenho, como linhas, formas e preenchimentos, sendo uma alternativa leve ao `Microsoft Paint`.
-#
+# 
 # ## 1. Instalar o `kolourpaint` no `Linux Ubuntu`
->>>>>>> codex/revise-project-for-kolourpaint-installation
 # 
 # Para instalar o `kolourpaint`, siga os passos abaixo:
 # 
@@ -91,37 +67,10 @@
 # 3. Instale o `kolourpaint` e verifique a instalação:
 #     ```bash
 #     sudo apt update
-<<<<<<< HEAD
-#     sudo apt install poppler-utils
-#     catfish -v
-#     ```
-# 
-# 
-# ## 2. Realizar uma busca simples
-# 
-# Você pode executar o `catfish` informando um diretório para a pesquisa:
-# ```bash
-# catfish ~/Documentos
-# ```
-# Esse comando abre a interface do programa iniciando a busca na pasta `Documentos`.
-# 
-# ## 3. Usar uma variável de terminal para definir o caminho de busca
-# 
-# Também é possível definir o diretório em uma variável antes de chamar o `catfish`:
-# ```bash
-# search_dir="~/Documentos"
-# catfish "$search_dir"
-# ```
-# 
-# ## Referências
-# 
-# [1] OPENAI. ***Instalar catfish no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/6862cf14-11c8-8002-8a1d-96488e72f5cf>. ChatGPT. Acessado em: 11/03/2025 14:23.
-# 
-=======
 #     sudo apt install kolourpaint
 #     kolourpaint --version
 #     ```
-#
+# 
 # ## 2. Abrir uma imagem existente
 # 
 # Você pode abrir o `kolourpaint` informando um arquivo de imagem:
@@ -129,7 +78,7 @@
 # kolourpaint ~/Imagens/exemplo.png
 # ```
 # Esse comando abre a interface do programa carregando a imagem `exemplo.png`.
-#
+# 
 # ## 3. Usar uma variável de terminal para definir a imagem
 # 
 # Também é possível definir o caminho em uma variável antes de chamar o `kolourpaint`:
@@ -137,9 +86,8 @@
 # img_path="~/Imagens/exemplo.png"
 # kolourpaint "$img_path"
 # ```
-#
+# 
 # ## Referências
 # 
 # [1] OPENAI. ***Instalar kolourpaint no Linux Ubuntu***. Disponível em: <https://chatgpt.com/c/68942e26-b7a0-832f-9c96-7c57044cb43a>. ChatGPT. Acessado em: 07/08/2025 05:21.
-#
->>>>>>> codex/revise-project-for-kolourpaint-installation
+# 


### PR DESCRIPTION
## Resumo
- remove a versão conflituosa `HEAD`
- mantém a documentação de instalação do `kolourpaint`

## Testes
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689547176df083229d28927b0170ce84